### PR TITLE
French and Chinese localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ registered for the device.
 | clientSecret | String | undefined | (REQUIRED) Used to encrypt the token returned upon successful fingerprint authentication. |
 | disableBackup | boolean | false | Set to true to remove the "USE BACKUP" button |
 | maxAttempts | number | 5 | The device max is 5 attempts.  Set this parameter if you want to allow fewer than 5 attempts.  |
-| locale | String | "en_US" | Change the language. Available languages (English: "en_US", Spanish: "es" |
+| locale | String | "en_US" | Change the language. Available languages (English: "en_US", Spanish: "es", French: "fr", Chinese (Simplified): "zh_CN"/"zh_SG", Chinese (Traditional): "zh"/"zh_HK"/"zh_TW"/"zh_MO" |
 | userAuthRequired | boolean | true | Require the user to authenticate with a fingerprint to authorize every use of the key.  New fingerprint enrollment will invalidate key and require backup authenticate to re-enable the fingerprint authentication dialog. |
 | dialogTitle | String | undefined | Set the title of the fingerprint authentication dialog. |
 | dialogMessage | String | undefined | Set the message of the fingerprint authentication dialog. |

--- a/plugin.xml
+++ b/plugin.xml
@@ -42,6 +42,13 @@
         <source-file src="res/android/values/fpauth-colors.xml" target-dir="res/values" />
         <source-file src="res/android/values/fpauth-strings.xml" target-dir="res/values" />
         <source-file src="res/android/values-es" target-dir="res" />
+        <source-file src="res/android/values-fr" target-dir="res" />
+        <source-file src="res/android/values-zh" target-dir="res" />
+        <source-file src="res/android/values-zh-rCN" target-dir="res" />
+        <source-file src="res/android/values-zh-rHK" target-dir="res" />
+        <source-file src="res/android/values-zh-rMO" target-dir="res" />
+        <source-file src="res/android/values-zh-rSG" target-dir="res" />
+        <source-file src="res/android/values-zh-rTW" target-dir="res" />
 
     </platform>
 

--- a/res/android/values-fr/fpauth-strings.xml
+++ b/res/android/values-fr/fpauth-strings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2015 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License
+  -->
+<resources>
+    <string name="cancel">Annuler</string>
+    <string name="use_backup">Utiliser la sauvegarde</string>
+    <string name="fingerprint_auth_dialog_title">Authentification par empreinte digitale</string>
+    <string name="ok">Ok</string>
+    <string name="fingerprint_description">Confirmer l\'empreinte pour continuer</string>
+    <string name="fingerprint_hint">Toucher le capteur</string>
+    <string name="fingerprint_not_recognized">Empreinte non reconnue. Essayer à nouveau.</string>
+    <string name="fingerprint_success">Empreinte reconnue</string>
+    <string name="new_fingerprint_enrolled_description">Une nouvelle empreinte digitale a été ajoutée à ce dispositif, de sorte que votre mot de passe est nécessaire.</string>
+    <string name="secure_lock_screen_required">Écran de verrouillage sécurisé nécessaire!</string>
+    <string name="fingerprint_too_many_attempts">Trop d\'essais. Essayer à nouveau ultérieurement.</string>
+</resources>

--- a/res/android/values-zh-rCN/fpauth-strings.xml
+++ b/res/android/values-zh-rCN/fpauth-strings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2015 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License
+  -->
+<resources>
+    <string name="cancel">取消</string>
+    <string name="use_backup">使用备份</string>
+    <string name="fingerprint_auth_dialog_title">指纹认证</string>
+    <string name="ok">确定</string>
+    <string name="fingerprint_description">确认指纹以继续</string>
+    <string name="fingerprint_hint">触控感应</string>
+    <string name="fingerprint_not_recognized">指纹无法识别，请重试一次。</string>
+    <string name="fingerprint_success">指纹识别成功</string>
+    <string name="new_fingerprint_enrolled_description">新的指纹资料加入此装置，需要您的密码。</string>
+    <string name="secure_lock_screen_required">需设定萤幕锁定</string>
+    <string name="fingerprint_too_many_attempts">尝试次数过多，请稍后再试。</string>
+</resources>

--- a/res/android/values-zh-rHK/fpauth-strings.xml
+++ b/res/android/values-zh-rHK/fpauth-strings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2015 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License
+  -->
+<resources>
+    <string name="cancel">取消</string>
+    <string name="use_backup">使用備份</string>
+    <string name="fingerprint_auth_dialog_title">指紋認證</string>
+    <string name="ok">確定</string>
+    <string name="fingerprint_description">確認指紋以繼續</string>
+    <string name="fingerprint_hint">觸控感應</string>
+    <string name="fingerprint_not_recognized">指紋無法識別，請重試一次。</string>
+    <string name="fingerprint_success">指紋識別成功</string>
+    <string name="new_fingerprint_enrolled_description">新的指紋資料加入此裝置，需要您的密碼。</string>
+    <string name="secure_lock_screen_required">需設定螢幕鎖定</string>
+    <string name="fingerprint_too_many_attempts">嘗試次數過多，請稍後再試。</string>
+</resources>

--- a/res/android/values-zh-rMO/fpauth-strings.xml
+++ b/res/android/values-zh-rMO/fpauth-strings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2015 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License
+  -->
+<resources>
+    <string name="cancel">取消</string>
+    <string name="use_backup">使用備份</string>
+    <string name="fingerprint_auth_dialog_title">指紋認證</string>
+    <string name="ok">確定</string>
+    <string name="fingerprint_description">確認指紋以繼續</string>
+    <string name="fingerprint_hint">觸控感應</string>
+    <string name="fingerprint_not_recognized">指紋無法識別，請重試一次。</string>
+    <string name="fingerprint_success">指紋識別成功</string>
+    <string name="new_fingerprint_enrolled_description">新的指紋資料加入此裝置，需要您的密碼。</string>
+    <string name="secure_lock_screen_required">需設定螢幕鎖定</string>
+    <string name="fingerprint_too_many_attempts">嘗試次數過多，請稍後再試。</string>
+</resources>

--- a/res/android/values-zh-rSG/fpauth-strings.xml
+++ b/res/android/values-zh-rSG/fpauth-strings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2015 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License
+  -->
+<resources>
+    <string name="cancel">取消</string>
+    <string name="use_backup">使用备份</string>
+    <string name="fingerprint_auth_dialog_title">指纹认证</string>
+    <string name="ok">确定</string>
+    <string name="fingerprint_description">确认指纹以继续</string>
+    <string name="fingerprint_hint">触控感应</string>
+    <string name="fingerprint_not_recognized">指纹无法识别，请重试一次。</string>
+    <string name="fingerprint_success">指纹识别成功</string>
+    <string name="new_fingerprint_enrolled_description">新的指纹资料加入此装置，需要您的密码。</string>
+    <string name="secure_lock_screen_required">需设定萤幕锁定</string>
+    <string name="fingerprint_too_many_attempts">尝试次数过多，请稍后再试。</string>
+</resources>

--- a/res/android/values-zh-rTW/fpauth-strings.xml
+++ b/res/android/values-zh-rTW/fpauth-strings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2015 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License
+  -->
+<resources>
+    <string name="cancel">取消</string>
+    <string name="use_backup">使用備份</string>
+    <string name="fingerprint_auth_dialog_title">指紋認證</string>
+    <string name="ok">確定</string>
+    <string name="fingerprint_description">確認指紋以繼續</string>
+    <string name="fingerprint_hint">觸控感應</string>
+    <string name="fingerprint_not_recognized">指紋無法識別，請重試一次。</string>
+    <string name="fingerprint_success">指紋識別成功</string>
+    <string name="new_fingerprint_enrolled_description">新的指紋資料加入此裝置，需要您的密碼。</string>
+    <string name="secure_lock_screen_required">需設定螢幕鎖定</string>
+    <string name="fingerprint_too_many_attempts">嘗試次數過多，請稍後再試。</string>
+</resources>

--- a/res/android/values-zh/fpauth-strings.xml
+++ b/res/android/values-zh/fpauth-strings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2015 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License
+  -->
+<resources>
+    <string name="cancel">取消</string>
+    <string name="use_backup">使用備份</string>
+    <string name="fingerprint_auth_dialog_title">指紋認證</string>
+    <string name="ok">確定</string>
+    <string name="fingerprint_description">確認指紋以繼續</string>
+    <string name="fingerprint_hint">觸控感應</string>
+    <string name="fingerprint_not_recognized">指紋無法識別，請重試一次。</string>
+    <string name="fingerprint_success">指紋識別成功</string>
+    <string name="new_fingerprint_enrolled_description">新的指紋資料加入此裝置，需要您的密碼。</string>
+    <string name="secure_lock_screen_required">需設定螢幕鎖定</string>
+    <string name="fingerprint_too_many_attempts">嘗試次數過多，請稍後再試。</string>
+</resources>

--- a/src/android/FingerprintAuth.java
+++ b/src/android/FingerprintAuth.java
@@ -195,7 +195,14 @@ public class FingerprintAuth extends CordovaPlugin {
             // Change locale settings in the app.
             DisplayMetrics dm = res.getDisplayMetrics();
             Configuration conf = res.getConfiguration();
-            conf.locale = new Locale(mLangCode.toLowerCase());
+            // A length of 5 entales a region specific locale string, ex: zh_HK.
+            // The two argument Locale constructor signature must be used in that case.
+            if (mLangCode.length() == 5) {
+                conf.locale = new Locale(mLangCode.substring(0, 2).toLowerCase(), 
+                    mLangCode.substring(mLangCode.length() - 2).toUpperCase());
+            } else {
+                conf.locale = new Locale(mLangCode.toLowerCase());
+            }
             res.updateConfiguration(conf, dm);
 
             if (isFingerprintAuthAvailable()) {


### PR DESCRIPTION
Added French and Chinese localization as well as handled a bug where region specific localizations were not being properly supplied to the Locale constructor.

Note: Had originally added the same dialog title functionality as eKazim in his [Russian localization fork](https://github.com/eKazim/cordova-plugin-android-fingerprint-auth), but his changes were very similar so I left those out.