### PR TITLE
Update plugin to encrypt and decrypt clientSecret

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ This plugin will open a native dialog fragment prompting the user to authenticat
 
 #Screenshots
 ###Fingerprint Auth Dialog
-![Fingerprint Auth Dialog](screenshots/fp_auth_dialog.jpg) | ![Fingerprint Auth Dialog Success](screenshots/fp_auth_dialog_success.png) | ![Fingerprint Auth Dialog Fail](screenshots/fp_auth_dialog_fail.jpg) | ![Fingerprint Auth Dialog Too Many](screenshots/fp_auth_dialog_too_many.jpg) | ![Fingerprint Auth Dialog No Backup](screenshots/fp_auth_dialog_no_backup.jpg) | ![Fingerprint Auth Dialog No Backup](screenshots/fp_auth_dialog_longer.png)
+![Fingerprint Auth Dialog](screenshots/fp_auth_dialog.jpg) ![Fingerprint Auth Dialog Success](screenshots/fp_auth_dialog_success.png) ![Fingerprint Auth Dialog Fail](screenshots/fp_auth_dialog_fail.jpg) ![Fingerprint Auth Dialog Too Many](screenshots/fp_auth_dialog_too_many.jpg) ![Fingerprint Auth Dialog No Backup](screenshots/fp_auth_dialog_no_backup.jpg) ![Fingerprint Auth Dialog No Backup](screenshots/fp_auth_dialog_longer.png)
 ###Backup Credentials
-![Confirm Password](screenshots/confirm_creds_pw.png) | ![Confirm PIN](screenshots/confirm_creds_pin.png) | ![Confirm Pattern](screenshots/confirm_creds_pattern.png)
+![Confirm Password](screenshots/confirm_creds_pw.png) ![Confirm PIN](screenshots/confirm_creds_pin.png) ![Confirm Pattern](screenshots/confirm_creds_pattern.png)
 
 
 #Installation

--- a/README.md
+++ b/README.md
@@ -26,54 +26,11 @@ buildToolsVersion "23.0.2"
 ```
 
 #API
-###FingerprintAuth.show(config, successCallback, errorCallbck)
-
-Opens a native dialog fragment to use the device hardware fingerprint scanner to authenticate against fingerprints
-registered for the device.
-
-#### Config Object
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| clientId | String | undefined | (REQUIRED) Used as the alias for your key in the Android Key Store. |
-| clientSecret | String | undefined | (REQUIRED) Used to encrypt the token returned upon successful fingerprint authentication. |
-| disableBackup | boolean | false | Set to true to remove the "USE BACKUP" button |
-| maxAttempts | number | 5 | The device max is 5 attempts.  Set this parameter if you want to allow fewer than 5 attempts.  |
-| locale | String | "en_US" | Change the language displayed on the authentication dialog.<br/><ul><li>English: "en_US"</li><li>Italian: "it"</li><li>Spanish: "es"</li><li>Russian: "ru"</li><li>French: "fr"</li><li>Chinese (Simplified): <ul><li>"zh_CN"</li><li>"zh_SG"</li></ul></li><li>Chinese (Traditional): <ul><li>"zh"</li><li>"zh_HK"</li><li>"zh_TW"</li><li>"zh_MO"</li></ul></li><li>Norwegian: "no"</li><li>Portuguese: "pt"</li><li>Japanese: "ja"</li></ul> |
-| userAuthRequired | boolean | true | Require the user to authenticate with a fingerprint to authorize every use of the key.  New fingerprint enrollment will invalidate key and require backup authenticate to re-enable the fingerprint authentication dialog. |
-| dialogTitle | String | undefined | Set the title of the fingerprint authentication dialog. |
-| dialogMessage | String | undefined | Set the message of the fingerprint authentication dialog. |
-| dialogHint | String | undefined | Set the hint displayed by the fingerprint icon on the fingerprint authentication dialog. |
-**Example**  
-
-```
-FingerprintAuth.show({
-            clientId: "myAppName",
-            clientSecret: "a_very_secret_encryption_key"
-        }, successCallback, errorCallback);
-
-/**
- * @return {withFingerprint:base64EncodedString, withPassword:boolean}
- */
-function successCallback(result) {
-    console.log("successCallback(): " + JSON.stringify(result));
-    if (result.withFingerprint) {
-        console.log("Successfully authenticated using a fingerprint");
-    } else if (result.withPassword) {
-        console.log("Authenticated with backup password");
-    }
-}
-
-function errorCallback(error) {
-    console.log(error); // "Fingerprint authentication not available"
-}
-
-```
-
 ###FingerprintAuth.isAvailable(successCallback, errorCallback)
 
 **Example**
 
-```
+```javascript
 FingerprintAuth.isAvailable(isAvailableSuccess, isAvailableError);
 
 /**
@@ -95,5 +52,130 @@ function isAvailableSuccess(result) {
 
 function isAvailableError(message) {
     console.log("isAvailableError(): " + message);
+}
+```
+
+###FingerprintAuth.init(config, successCallback, errorCallbck)
+
+Opens a native dialog fragment to use the device hardware fingerprint scanner to authenticate against fingerprints
+registered for the device.
+
+#### Config Object
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| clientId | String | undefined | (REQUIRED) Used as the alias for your key in the Android Key Store. |
+| clientSecret | String | undefined | (REQUIRED) Data to be encrypted by the fingerprint plugin. |
+| disableBackup | boolean | false | Set to true to remove the "USE BACKUP" button |
+| maxAttempts | number | 5 | The device max is 5 attempts.  Set this parameter if you want to allow fewer than 5 attempts.  |
+| locale | String | "en_US" | Change the language displayed on the authentication dialog.<br/><ul><li>English: "en_US"</li><li>Italian: "it"</li><li>Spanish: "es"</li><li>Russian: "ru"</li><li>French: "fr"</li><li>Chinese (Simplified): <ul><li>"zh_CN"</li><li>"zh_SG"</li></ul></li><li>Chinese (Traditional): <ul><li>"zh"</li><li>"zh_HK"</li><li>"zh_TW"</li><li>"zh_MO"</li></ul></li><li>Norwegian: "no"</li><li>Portuguese: "pt"</li><li>Japanese: "ja"</li></ul> |
+| userAuthRequired | boolean | true | Require the user to authenticate with a fingerprint to authorize every use of the key.  New fingerprint enrollment will invalidate key and require backup authenticate to re-enable the fingerprint authentication dialog. |
+| dialogTitle | String | undefined | Set the title of the fingerprint authentication dialog. |
+| dialogMessage | String | undefined | Set the message of the fingerprint authentication dialog. |
+| dialogHint | String | undefined | Set the hint displayed by the fingerprint icon on the fingerprint authentication dialog. |
+**Example**  
+
+```javascript
+FingerprintAuth.init({
+            clientId: "myAppName",
+            clientSecret: "data_to_be_encrypted"
+        }, successCallback, errorCallback);
+
+/**
+ * @return {withFingerprint:clientSecretBase64CryptedString, withPassword:boolean}
+ */
+function successCallback(result) {
+    console.log("successCallback(): " + JSON.stringify(result));
+    if (result.withFingerprint) {
+        console.log("Successfully encrypting data");
+        console.log("Encrypted data: " + result.withFingerprint);
+    } else if (result.withPassword) {
+        console.log("Authenticated with backup password");
+    }
+}
+
+function errorCallback(error) {
+    console.log(error); // "Fingerprint authentication not available"
+}
+
+```
+
+###FingerprintAuth.show(config, successCallback, errorCallback)
+
+Opens a native dialog fragment to use the device hardware fingerprint scanner to authenticate against fingerprints
+registered for the device.
+
+#### Config Object
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| clientId | String | undefined | (REQUIRED) Used as the alias for your key in the Android Key Store. |
+| clientSecret | String | undefined | (REQUIRED) Data to be decrypted (the base64 returned by `init` function) by the fingerprint plugin. |
+| disableBackup | boolean | false | Set to true to remove the "USE BACKUP" button |
+| maxAttempts | number | 5 | The device max is 5 attempts.  Set this parameter if you want to allow fewer than 5 attempts.  |
+| locale | String | "en_US" | Change the language displayed on the authentication dialog.<br/><ul><li>English: "en_US"</li><li>Italian: "it"</li><li>Spanish: "es"</li><li>Russian: "ru"</li><li>French: "fr"</li><li>Chinese (Simplified): <ul><li>"zh_CN"</li><li>"zh_SG"</li></ul></li><li>Chinese (Traditional): <ul><li>"zh"</li><li>"zh_HK"</li><li>"zh_TW"</li><li>"zh_MO"</li></ul></li><li>Norwegian: "no"</li><li>Portuguese: "pt"</li><li>Japanese: "ja"</li></ul> |
+| userAuthRequired | boolean | true | Require the user to authenticate with a fingerprint to authorize every use of the key.  New fingerprint enrollment will invalidate key and require backup authenticate to re-enable the fingerprint authentication dialog. |
+| dialogTitle | String | undefined | Set the title of the fingerprint authentication dialog. |
+| dialogMessage | String | undefined | Set the message of the fingerprint authentication dialog. |
+| dialogHint | String | undefined | Set the hint displayed by the fingerprint icon on the fingerprint authentication dialog. |
+**Example**  
+
+```javascript
+FingerprintAuth.show({
+            clientId: "myAppName",
+            clientSecret: "data_to_be_decrypted"
+        }, successCallback, errorCallback);
+
+/**
+ * @return {withFingerprint:clientSecretDecryptedString, withPassword:boolean}
+ */
+function successCallback(result) {
+    console.log("successCallback(): " + JSON.stringify(result));
+    if (result.withFingerprint) {
+        console.log("Successfully authenticated using a fingerprint");
+    } else if (result.withPassword) {
+        console.log("Authenticated with backup password");
+    }
+}
+
+function errorCallback(error) {
+    console.log(error); // "Fingerprint authentication not available"
+}
+
+```
+
+###FingerprintAuth.delete(config, successCallback, errorCallback)
+
+Used to reset the fingerprint plugin.
+
+#### Config Object
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| clientId | String | undefined | (REQUIRED) Used as the alias for your key in the Android Key Store. |
+
+**Example**
+
+```javascript
+FingerprintAuth.delete({
+            clientId: "myAppName"
+        }, successCallback, errorCallback);
+
+/**
+ * @return {
+ *      isAvailable:boolean,
+ *      isHardwareDetected:boolean,
+ *      hasEnrolledFingerprints:boolean
+ *   }
+ */
+function successCallback(result) {
+    console.log("FingerprintAuth available: " + JSON.stringify(result));
+    if (result.isAvailable) {
+        FingerprintAuth.show({
+                    clientId: "myAppName",
+                    clientSecret: "a_very_secret_encryption_key"
+                }, successCallback, errorCallback);
+    }
+}
+
+function errorCallback(error) {
+    console.log(error);
 }
 ```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ compileSdkVersion 23
 buildToolsVersion "23.0.2"
 ```
 
+#How to use
+- Call `isAvailable` to check the fingerprint status
+- Call `init` to encrypt `clientSecret`, when the fingerprint is activated into your App
+- Call `show` to decrypt `clientSecret` returned by `init`
+- Call `delete` when you want to reset all the fingerprint data and settings
+
 #API
 ###FingerprintAuth.isAvailable(successCallback, errorCallback)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-android-fingerprint-auth",
-  "version": "0.3.4",
+  "version": "1.0.0",
   "description": "Cordova plugin to use Android fingerprint authentication API",
   "cordova": {
     "id": "cordova-plugin-android-fingerprint-auth",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-android-fingerprint-auth"
-        version="0.3.4">
+        version="1.0.0">
     <name>FingerprintAuth</name>
     <description>Cordova plugin to use Android fingerprint authentication API</description>
     <license>Apache 2.0</license>

--- a/src/android/FingerprintAuth.java
+++ b/src/android/FingerprintAuth.java
@@ -493,7 +493,7 @@ public class FingerprintAuth extends CordovaPlugin {
      * @param context  App context
      * @param name     Preference name
      * @param key      Preference key
-     * @return Returns true if deleted otherwise
+     * @return Returns true if deleted otherwise false
      */
     public static boolean deleteStringPreference(Context context, String name, String key) {
         SharedPreferences sharedPreferences = context.getSharedPreferences(name, Context.MODE_PRIVATE);

--- a/src/android/FingerprintAuth.java
+++ b/src/android/FingerprintAuth.java
@@ -7,12 +7,12 @@ import org.apache.cordova.CordovaInterface;
 
 import android.annotation.TargetApi;
 import android.app.KeyguardManager;
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.hardware.fingerprint.FingerprintManager;
-import android.os.Bundle;
 import android.security.keystore.KeyGenParameterSpec;
-import android.security.keystore.KeyPermanentlyInvalidatedException;
 import android.security.keystore.KeyProperties;
 import android.util.Base64;
 import android.util.DisplayMetrics;
@@ -24,8 +24,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -40,18 +40,18 @@ import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.KeyGenerator;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
 
 @TargetApi(23)
 public class FingerprintAuth extends CordovaPlugin {
-
     public static final String TAG = "FingerprintAuth";
     public static String packageName;
 
     private static final String DIALOG_FRAGMENT_TAG = "FpAuthDialog";
     private static final String ANDROID_KEY_STORE = "AndroidKeyStore";
 
-    KeyguardManager mKeyguardManager;
-    FingerprintAuthenticationDialogFragment mFragment;
+    public KeyguardManager mKeyguardManager;
+    public FingerprintAuthenticationDialogFragment mFragment;
     public static KeyStore mKeyStore;
     public static KeyGenerator mKeyGenerator;
     public static Cipher mCipher;
@@ -68,6 +68,7 @@ public class FingerprintAuth extends CordovaPlugin {
      * Used to encrypt token
      */
     private static String mClientSecret;
+    private static boolean mCipherModeCrypt;
 
     /**
      * Options
@@ -79,6 +80,9 @@ public class FingerprintAuth extends CordovaPlugin {
     public static String mDialogTitle;
     public static String mDialogMessage;
     public static String mDialogHint;
+    public static Context mContext;
+    public static final String FINGERPRINT_PREF_NAME = "fingerprint_auth";
+    public static final String FINGERPRINT_PREF_IV = "aes_iv";
 
     /**
      * Constructor.
@@ -93,26 +97,24 @@ public class FingerprintAuth extends CordovaPlugin {
      * @param cordova The context of the main Activity.
      * @param webView The CordovaWebView Cordova is running in.
      */
-
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
         super.initialize(cordova, webView);
         Log.v(TAG, "Init FingerprintAuth");
+
         packageName = cordova.getActivity().getApplicationContext().getPackageName();
         mPluginResult = new PluginResult(PluginResult.Status.NO_RESULT);
+        mContext = cordova.getActivity().getApplicationContext();
 
         if (android.os.Build.VERSION.SDK_INT < 23) {
             return;
         }
 
         mKeyguardManager = cordova.getActivity().getSystemService(KeyguardManager.class);
-        mFingerPrintManager = cordova.getActivity().getApplicationContext()
-                .getSystemService(FingerprintManager.class);
+        mFingerPrintManager = cordova.getActivity().getApplicationContext().getSystemService(FingerprintManager.class);
 
         try {
-            mKeyGenerator = KeyGenerator.getInstance(
-                    KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
+            mKeyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
             mKeyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
-
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException("Failed to get an instance of KeyGenerator", e);
         } catch (NoSuchProviderException e) {
@@ -122,9 +124,7 @@ public class FingerprintAuth extends CordovaPlugin {
         }
 
         try {
-            mCipher = Cipher.getInstance(KeyProperties.KEY_ALGORITHM_AES + "/"
-                    + KeyProperties.BLOCK_MODE_CBC + "/"
-                    + KeyProperties.ENCRYPTION_PADDING_PKCS7);
+            mCipher = Cipher.getInstance(KeyProperties.KEY_ALGORITHM_AES + "/" + KeyProperties.BLOCK_MODE_CBC + "/" + KeyProperties.ENCRYPTION_PADDING_PKCS7);
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException("Failed to get an instance of Cipher", e);
         } catch (NoSuchPaddingException e) {
@@ -140,9 +140,7 @@ public class FingerprintAuth extends CordovaPlugin {
      * @param callbackContext The callback id used when calling back into JavaScript.
      * @return A PluginResult object with a status and message.
      */
-    public boolean execute(final String action,
-                           JSONArray args,
-                           CallbackContext callbackContext) throws JSONException {
+    public boolean execute(final String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
         mCallbackContext = callbackContext;
         Log.v(TAG, "FingerprintAuth action: " + action);
         if (android.os.Build.VERSION.SDK_INT < 23) {
@@ -155,7 +153,12 @@ public class FingerprintAuth extends CordovaPlugin {
 
         final JSONObject arg_object = args.getJSONObject(0);
 
-        if (action.equals("authenticate")) {
+        if (action.equals("authenticate") || action.equals("init")) { // authenticate is used to decrypt user's password, init is used to encrypt user's password
+            if (action.equals("authenticate")) {
+                mCipherModeCrypt = false; // Decrypt mode
+            } else if (action.equals("init")) {
+                mCipherModeCrypt = true; // Encrypt mode
+            }
             if (!arg_object.has("clientId") || !arg_object.has("clientSecret")) {
                 mPluginResult = new PluginResult(PluginResult.Status.ERROR);
                 mCallbackContext.error("Missing required parameters");
@@ -198,7 +201,7 @@ public class FingerprintAuth extends CordovaPlugin {
             // A length of 5 entales a region specific locale string, ex: zh_HK.
             // The two argument Locale constructor signature must be used in that case.
             if (mLangCode.length() == 5) {
-                conf.locale = new Locale(mLangCode.substring(0, 2).toLowerCase(), 
+                conf.locale = new Locale(mLangCode.substring(0, 2).toLowerCase(),
                     mLangCode.substring(mLangCode.length() - 2).toUpperCase());
             } else {
                 conf.locale = new Locale(mLangCode.toLowerCase());
@@ -207,14 +210,10 @@ public class FingerprintAuth extends CordovaPlugin {
 
             if (isFingerprintAuthAvailable()) {
                 SecretKey key = getSecretKey();
-                boolean isCipherInit = true;
                 if (key == null) {
                     if (createKey()) {
                         key = getSecretKey();
                     }
-                }
-                if (key != null && !initCipher()) {
-                    isCipherInit = false;
                 }
                 if (key != null) {
                     cordova.getActivity().runOnUiThread(new Runnable() {
@@ -222,27 +221,19 @@ public class FingerprintAuth extends CordovaPlugin {
                             // Set up the crypto object for later. The object will be authenticated by use
                             // of the fingerprint.
                             mFragment = new FingerprintAuthenticationDialogFragment();
-//                            Bundle bundle = new Bundle();
-//                            bundle.putBoolean("disableBackup", mDisableBackup);
-//                            mFragment.setArguments(bundle);
-
                             if (initCipher()) {
                                 mFragment.setCancelable(false);
                                 // Show the fingerprint dialog. The user has the option to use the fingerprint with
                                 // crypto, or you can fall back to using a server-side verified password.
                                 mFragment.setCryptoObject(new FingerprintManager.CryptoObject(mCipher));
-                                mFragment.show(cordova.getActivity()
-                                        .getFragmentManager(), DIALOG_FRAGMENT_TAG);
+                                mFragment.show(cordova.getActivity().getFragmentManager(), DIALOG_FRAGMENT_TAG);
                             } else {
                                 if (!mDisableBackup) {
                                     // This happens if the lock screen has been disabled or or a fingerprint got
                                     // enrolled. Thus show the dialog to authenticate with their password
-                                    mFragment.setCryptoObject(new FingerprintManager
-                                            .CryptoObject(mCipher));
-                                    mFragment.setStage(FingerprintAuthenticationDialogFragment
-                                            .Stage.NEW_FINGERPRINT_ENROLLED);
-                                    mFragment.show(cordova.getActivity().getFragmentManager(),
-                                            DIALOG_FRAGMENT_TAG);
+                                    mFragment.setCryptoObject(new FingerprintManager.CryptoObject(mCipher));
+                                    mFragment.setStage(FingerprintAuthenticationDialogFragment.Stage.NEW_FINGERPRINT_ENROLLED);
+                                    mFragment.show(cordova.getActivity().getFragmentManager(), DIALOG_FRAGMENT_TAG);
                                 } else {
                                     mCallbackContext.error("Failed to init Cipher and backup disabled.");
                                     mPluginResult = new PluginResult(PluginResult.Status.ERROR);
@@ -255,7 +246,6 @@ public class FingerprintAuth extends CordovaPlugin {
                 } else {
                     mCallbackContext.sendPluginResult(mPluginResult);
                 }
-
             } else {
                 mPluginResult = new PluginResult(PluginResult.Status.ERROR);
                 mCallbackContext.error("Fingerprint authentication not available");
@@ -271,13 +261,27 @@ public class FingerprintAuth extends CordovaPlugin {
             mCallbackContext.success(resultJson);
             mCallbackContext.sendPluginResult(mPluginResult);
             return true;
+        } else if (action.equals("delete")) {
+            mClientId = arg_object.getString("clientId");
+            boolean deleted = deleteIV();
+            if (deleted) {
+                mPluginResult = new PluginResult(PluginResult.Status.OK);
+                mCallbackContext.success();
+            } else {
+                JSONObject resultJson = new JSONObject();
+                resultJson.put("error", "Error while deleting Fingerprint data.");
+                mPluginResult = new PluginResult(PluginResult.Status.ERROR);
+                mCallbackContext.error(resultJson);
+            }
+
+            mCallbackContext.sendPluginResult(mPluginResult);
+            return true;
         }
         return false;
     }
 
     private boolean isFingerprintAuthAvailable() {
-        return mFingerPrintManager.isHardwareDetected()
-                && mFingerPrintManager.hasEnrolledFingerprints();
+        return mFingerPrintManager.isHardwareDetected() && mFingerPrintManager.hasEnrolledFingerprints();
     }
 
     /**
@@ -292,18 +296,37 @@ public class FingerprintAuth extends CordovaPlugin {
         boolean initCipher = false;
         String errorMessage = "";
         String initCipherExceptionErrorPrefix = "Failed to init Cipher: ";
+        byte[] mCipherIV;
+
         try {
             SecretKey key = getSecretKey();
-            mCipher.init(Cipher.ENCRYPT_MODE, key);
+
+            if (mCipherModeCrypt) {
+                mCipher.init(Cipher.ENCRYPT_MODE, key);
+                mCipherIV = mCipher.getIV();
+                setStringPreference(mContext, FINGERPRINT_PREF_NAME, FINGERPRINT_PREF_IV, new String(Base64.encode(mCipherIV, Base64.NO_WRAP)));
+            } else {
+                mCipherIV = Base64.decode(getStringPreference(mContext, FINGERPRINT_PREF_NAME, FINGERPRINT_PREF_IV), Base64.NO_WRAP);
+                IvParameterSpec ivspec = new IvParameterSpec(mCipherIV);
+                mCipher.init(Cipher.DECRYPT_MODE, key, ivspec);
+            }
             initCipher = true;
-        } catch (InvalidKeyException e) {
-            errorMessage = initCipherExceptionErrorPrefix
-                    + "InvalidKeyException: " + e.toString();
+        } catch (Exception e) {
+            errorMessage = initCipherExceptionErrorPrefix + "Exception: " + e.toString();
         }
         if (!initCipher) {
             Log.e(TAG, errorMessage);
         }
         return initCipher;
+    }
+
+    public static boolean deleteIV() {
+        try {
+            mKeyStore.deleteEntry(mClientId);
+        } catch (KeyStoreException e) {
+            Log.e(TAG, "Failed to get SecretKey from KeyStore: KeyStoreException: " + e.toString());
+        }
+        return deleteStringPreference(mContext, FINGERPRINT_PREF_NAME, FINGERPRINT_PREF_IV);
     }
 
     private static SecretKey getSecretKey() {
@@ -314,20 +337,15 @@ public class FingerprintAuth extends CordovaPlugin {
             mKeyStore.load(null);
             key = (SecretKey) mKeyStore.getKey(mClientId, null);
         } catch (KeyStoreException e) {
-            errorMessage = getSecretKeyExceptionErrorPrefix
-                    + "KeyStoreException: " + e.toString();;
+            errorMessage = getSecretKeyExceptionErrorPrefix + "KeyStoreException: " + e.toString();
         } catch (CertificateException e) {
-            errorMessage = getSecretKeyExceptionErrorPrefix
-                    + "CertificateException: " + e.toString();;
+            errorMessage = getSecretKeyExceptionErrorPrefix + "CertificateException: " + e.toString();
         } catch (UnrecoverableKeyException e) {
-            errorMessage = getSecretKeyExceptionErrorPrefix
-                    + "UnrecoverableKeyException: " + e.toString();;
+            errorMessage = getSecretKeyExceptionErrorPrefix + "UnrecoverableKeyException: " + e.toString();
         } catch (IOException e) {
-            errorMessage = getSecretKeyExceptionErrorPrefix
-                    + "IOException: " + e.toString();;
+            errorMessage = getSecretKeyExceptionErrorPrefix + "IOException: " + e.toString();
         } catch (NoSuchAlgorithmException e) {
-            errorMessage = getSecretKeyExceptionErrorPrefix
-                    + "NoSuchAlgorithmException: " + e.toString();;
+            errorMessage = getSecretKeyExceptionErrorPrefix + "NoSuchAlgorithmException: " + e.toString();
         }
         if (key == null) {
             Log.e(TAG, errorMessage);
@@ -350,29 +368,21 @@ public class FingerprintAuth extends CordovaPlugin {
             mKeyStore.load(null);
             // Set the alias of the entry in Android KeyStore where the key will appear
             // and the constrains (purposes) in the constructor of the Builder
-            mKeyGenerator.init(new KeyGenParameterSpec.Builder(mClientId,
-                    KeyProperties.PURPOSE_ENCRYPT |
-                            KeyProperties.PURPOSE_DECRYPT)
+            mKeyGenerator.init(new KeyGenParameterSpec.Builder(mClientId, KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
                     .setBlockModes(KeyProperties.BLOCK_MODE_CBC)
-                            // Require the user to authenticate with a fingerprint to authorize every use
-                            // of the key
                     .setUserAuthenticationRequired(mUserAuthRequired)
                     .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
                     .build());
             mKeyGenerator.generateKey();
             isKeyCreated = true;
         } catch (NoSuchAlgorithmException e) {
-            errorMessage = createKeyExceptionErrorPrefix
-                    + "NoSuchAlgorithmException: " + e.toString();;
+            errorMessage = createKeyExceptionErrorPrefix + "NoSuchAlgorithmException: " + e.toString();
         } catch (InvalidAlgorithmParameterException e) {
-            errorMessage = createKeyExceptionErrorPrefix
-                    + "InvalidAlgorithmParameterException: " + e.toString();;
+            errorMessage = createKeyExceptionErrorPrefix + "InvalidAlgorithmParameterException: " + e.toString();
         } catch (CertificateException e) {
-            errorMessage = createKeyExceptionErrorPrefix
-                    + "CertificateException: " + e.toString();;
+            errorMessage = createKeyExceptionErrorPrefix + "CertificateException: " + e.toString();
         } catch (IOException e) {
-            errorMessage = createKeyExceptionErrorPrefix
-                    + "IOException: " + e.toString();;
+            errorMessage = createKeyExceptionErrorPrefix + "IOException: " + e.toString();
         }
         if (!isKeyCreated) {
             Log.e(TAG, errorMessage);
@@ -381,38 +391,47 @@ public class FingerprintAuth extends CordovaPlugin {
         return isKeyCreated;
     }
 
-    public static void onAuthenticated(boolean withFingerprint) {
+    public static void onAuthenticated(boolean withFingerprint, FingerprintManager.AuthenticationResult result) {
         JSONObject resultJson = new JSONObject();
         String errorMessage = "";
         boolean createdResultJson = false;
-        try {
+        String output;
 
+        try {
             if (withFingerprint) {
                 // If the user has authenticated with fingerprint, verify that using cryptography and
-                // then return the encrypted token
-                byte[] encrypted = tryEncrypt();
-                resultJson.put("withFingerprint", Base64.encodeToString(encrypted, 0 /* flags */));
+                // then return the encrypted (in Base 64) or decrypted mClientSecret
+                byte[] encrypted;
+                if (mCipherModeCrypt) {
+                    encrypted = result.getCryptoObject().getCipher().doFinal(mClientSecret.getBytes("UTF-8"));
+                    output = Base64.encodeToString(encrypted, Base64.NO_WRAP);
+                } else {
+                    encrypted = result.getCryptoObject().getCipher().doFinal(Base64.decode(mClientSecret, Base64.NO_WRAP));
+                    output =  new String(encrypted, "UTF-8");
+                }
+
+                resultJson.put("withFingerprint", output);
             } else {
                 // Authentication happened with backup password.
                 resultJson.put("withPassword", true);
 
-                // if failed to init cipher because of InvalidKeyException, create new key
+                // If failed to init cipher because of InvalidKeyException, create new key
                 if (!initCipher()) {
                     createKey();
                 }
             }
             createdResultJson = true;
         } catch (BadPaddingException e) {
-            errorMessage = "Failed to encrypt the data with the generated key:" +
-                    " BadPaddingException:  " + e.toString();
+            errorMessage = "Failed to encrypt the data with the generated key:" + " BadPaddingException:  " + e.toString();
             Log.e(TAG, errorMessage);
         } catch (IllegalBlockSizeException e) {
-            errorMessage = "Failed to encrypt the data with the generated key: " +
-                    "IllegalBlockSizeException: " + e.toString();
+            errorMessage = "Failed to encrypt the data with the generated key: " + "IllegalBlockSizeException: " + e.toString();
             Log.e(TAG, errorMessage);
         } catch (JSONException e) {
             errorMessage = "Failed to set resultJson key value pair: " + e.toString();
             Log.e(TAG, errorMessage);
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
         }
 
         if (createdResultJson) {
@@ -433,17 +452,53 @@ public class FingerprintAuth extends CordovaPlugin {
         mCallbackContext.error(errString.toString());
     }
 
-    /**
-     * Tries to encrypt some data with the generated key in {@link #createKey} which is
-     * only works if the user has just authenticated via fingerprint.
-     */
-    private static byte[] tryEncrypt() throws BadPaddingException, IllegalBlockSizeException {
-        return mCipher.doFinal(mClientSecret.getBytes());
-    }
-
     public static boolean setPluginResultError(String errorMessage) {
         mCallbackContext.error(errorMessage);
         mPluginResult = new PluginResult(PluginResult.Status.ERROR);
         return false;
+    }
+
+    /**
+     * Get a String preference
+     *
+     * @param context  App context
+     * @param name     Preference name
+     * @param key      Preference key
+     * @return Requested preference, if not exist returns null
+     */
+    public static String getStringPreference(Context context, String name, String key) {
+        SharedPreferences sharedPreferences = context.getSharedPreferences(name, Context.MODE_PRIVATE);
+        return sharedPreferences.getString(key, null);
+    }
+
+    /**
+     * Set a String preference
+     *
+     * @param context  App context
+     * @param name     Preference name
+     * @param key      Preference key
+     * @param value    Preference value to be saved
+     */
+    public static void setStringPreference(Context context, String name, String key, String value) {
+        SharedPreferences sharedPreferences = context.getSharedPreferences(name, Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+
+        editor.putString(key, value);
+        editor.apply();
+    }
+
+    /**
+     * Delete a String preference
+     *
+     * @param context  App context
+     * @param name     Preference name
+     * @param key      Preference key
+     * @return Returns true if deleted otherwise
+     */
+    public static boolean deleteStringPreference(Context context, String name, String key) {
+        SharedPreferences sharedPreferences = context.getSharedPreferences(name, Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+
+        return editor.remove(key).commit();
     }
 }

--- a/src/android/FingerprintAuthenticationDialogFragment.java
+++ b/src/android/FingerprintAuthenticationDialogFragment.java
@@ -242,7 +242,7 @@ public class FingerprintAuthenticationDialogFragment extends DialogFragment
         if (requestCode == REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS) {
             // Challenge completed, proceed with using cipher
             if (resultCode == getActivity().RESULT_OK) {
-                FingerprintAuth.onAuthenticated(false /* used backup */);
+                FingerprintAuth.onAuthenticated(false /* used backup */, null);
             } else {
                 // The user canceled or didn’t complete the lock screen
                 // operation. Go to error/cancellation flow.
@@ -253,10 +253,10 @@ public class FingerprintAuthenticationDialogFragment extends DialogFragment
     }
 
     @Override
-    public void onAuthenticated() {
+    public void onAuthenticated(FingerprintManager.AuthenticationResult result) {
         // Callback from FingerprintUiHelper. Let the activity know that authentication was
         // successful.
-        FingerprintAuth.onAuthenticated(true /* withFingerprint */);
+        FingerprintAuth.onAuthenticated(true /* withFingerprint */, result);
         dismiss();
     }
 

--- a/src/android/FingerprintUiHelper.java
+++ b/src/android/FingerprintUiHelper.java
@@ -40,6 +40,7 @@ public class FingerprintUiHelper extends FingerprintManager.AuthenticationCallba
     private final Callback mCallback;
     private CancellationSignal mCancellationSignal;
     private int mAttempts = 0;
+    private static FingerprintManager.AuthenticationResult fingerprintResult;
 
     boolean mSelfCancelled;
 
@@ -147,6 +148,7 @@ public class FingerprintUiHelper extends FingerprintManager.AuthenticationCallba
 
     @Override
     public void onAuthenticationSucceeded(FingerprintManager.AuthenticationResult result) {
+        fingerprintResult = result;
         mErrorTextView.removeCallbacks(mResetErrorTextRunnable);
         int ic_fingerprint_success_id = mContext.getResources()
                 .getIdentifier("ic_fingerprint_success", "drawable", FingerprintAuth.packageName);
@@ -162,7 +164,7 @@ public class FingerprintUiHelper extends FingerprintManager.AuthenticationCallba
         mIcon.postDelayed(new Runnable() {
             @Override
             public void run() {
-                mCallback.onAuthenticated();
+                mCallback.onAuthenticated(fingerprintResult);
             }
         }, SUCCESS_DELAY_MILLIS);
     }
@@ -199,7 +201,7 @@ public class FingerprintUiHelper extends FingerprintManager.AuthenticationCallba
 
     public interface Callback {
 
-        void onAuthenticated();
+        void onAuthenticated(FingerprintManager.AuthenticationResult result);
 
         void onError(CharSequence errString);
     }

--- a/www/FingerprintAuth.js
+++ b/www/FingerprintAuth.js
@@ -1,53 +1,50 @@
-cordova.define("cordova-plugin-android-fingerprint-auth.FingerprintAuth", function(require, exports, module) {
-  function FingerprintAuth() {
-  }
+function FingerprintAuth() {}
 
-  FingerprintAuth.prototype.show = function (params, successCallback, errorCallback) {
-      cordova.exec(
-          successCallback,
-          errorCallback,
-          "FingerprintAuth",  // Java Class
-          "authenticate", // action
-          [ // Array of arguments to pass to the Java class
-              params
-          ]
-      );
-  };
+FingerprintAuth.prototype.show = function (params, successCallback, errorCallback) {
+    cordova.exec(
+        successCallback,
+        errorCallback,
+        "FingerprintAuth",  // Java Class
+        "authenticate", // action
+        [ // Array of arguments to pass to the Java class
+            params
+        ]
+    );
+};
 
-  FingerprintAuth.prototype.init = function (params, successCallback, errorCallback) {
-      cordova.exec(
-          successCallback,
-          errorCallback,
-          "FingerprintAuth",  // Java Class
-          "init", // action
-          [ // Array of arguments to pass to the Java class
-              params
-          ]
-      );
-  };
+FingerprintAuth.prototype.init = function (params, successCallback, errorCallback) {
+    cordova.exec(
+        successCallback,
+        errorCallback,
+        "FingerprintAuth",  // Java Class
+        "init", // action
+        [ // Array of arguments to pass to the Java class
+            params
+        ]
+    );
+};
 
-  FingerprintAuth.prototype.delete = function (params, successCallback, errorCallback) {
-      cordova.exec(
-          successCallback,
-          errorCallback,
-          "FingerprintAuth",  // Java Class
-          "delete", // action
-          [ // Array of arguments to pass to the Java class
-              params
-          ]
-      );
-  };
+FingerprintAuth.prototype.delete = function (params, successCallback, errorCallback) {
+    cordova.exec(
+        successCallback,
+        errorCallback,
+        "FingerprintAuth",  // Java Class
+        "delete", // action
+        [ // Array of arguments to pass to the Java class
+            params
+        ]
+    );
+};
 
-  FingerprintAuth.prototype.isAvailable = function (successCallback, errorCallback) {
-      cordova.exec(
-          successCallback,
-          errorCallback,
-          "FingerprintAuth",  // Java Class
-          "availability", // action
-          [{}]
-      );
-  };
+FingerprintAuth.prototype.isAvailable = function (successCallback, errorCallback) {
+    cordova.exec(
+        successCallback,
+        errorCallback,
+        "FingerprintAuth",  // Java Class
+        "availability", // action
+        [{}]
+    );
+};
 
-  FingerprintAuth = new FingerprintAuth();
-  module.exports = FingerprintAuth;
-});
+FingerprintAuth = new FingerprintAuth();
+module.exports = FingerprintAuth;

--- a/www/FingerprintAuth.js
+++ b/www/FingerprintAuth.js
@@ -1,27 +1,53 @@
-function FingerprintAuth() {
-}
+cordova.define("cordova-plugin-android-fingerprint-auth.FingerprintAuth", function(require, exports, module) {
+  function FingerprintAuth() {
+  }
 
-FingerprintAuth.prototype.show = function (params, successCallback, errorCallback) {
-    cordova.exec(
-        successCallback,
-        errorCallback,
-        "FingerprintAuth",  // Java Class
-        "authenticate", // action
-        [ // Array of arguments to pass to the Java class
-            params
-        ]
-    );
-};
+  FingerprintAuth.prototype.show = function (params, successCallback, errorCallback) {
+      cordova.exec(
+          successCallback,
+          errorCallback,
+          "FingerprintAuth",  // Java Class
+          "authenticate", // action
+          [ // Array of arguments to pass to the Java class
+              params
+          ]
+      );
+  };
 
-FingerprintAuth.prototype.isAvailable = function (successCallback, errorCallback) {
-    cordova.exec(
-        successCallback,
-        errorCallback,
-        "FingerprintAuth",  // Java Class
-        "availability", // action
-        [{}]
-    );
-};
+  FingerprintAuth.prototype.init = function (params, successCallback, errorCallback) {
+      cordova.exec(
+          successCallback,
+          errorCallback,
+          "FingerprintAuth",  // Java Class
+          "init", // action
+          [ // Array of arguments to pass to the Java class
+              params
+          ]
+      );
+  };
 
-FingerprintAuth = new FingerprintAuth();
-module.exports = FingerprintAuth;
+  FingerprintAuth.prototype.delete = function (params, successCallback, errorCallback) {
+      cordova.exec(
+          successCallback,
+          errorCallback,
+          "FingerprintAuth",  // Java Class
+          "delete", // action
+          [ // Array of arguments to pass to the Java class
+              params
+          ]
+      );
+  };
+
+  FingerprintAuth.prototype.isAvailable = function (successCallback, errorCallback) {
+      cordova.exec(
+          successCallback,
+          errorCallback,
+          "FingerprintAuth",  // Java Class
+          "availability", // action
+          [{}]
+      );
+  };
+
+  FingerprintAuth = new FingerprintAuth();
+  module.exports = FingerprintAuth;
+});


### PR DESCRIPTION
We read about issue #5 and we updated the plugin with encrypt and decrypt features.

Now the usage flow is a bit different:
- Call `isAvailable` to check the fingerprint status
- Call `init` to encrypt `clientSecret`, when the fingerprint is activated into your App
- Call `show` to decrypt `clientSecret` returned by `init`
- Call `delete` when you want to reset all the fingerprint data and settings