### PR TITLE
On "PIN fallback", callback function is not called

### DIFF
--- a/src/android/FingerprintAuth.java
+++ b/src/android/FingerprintAuth.java
@@ -715,6 +715,7 @@ public class FingerprintAuth extends CordovaPlugin {
     private void showAuthenticationScreen() {
         Intent intent = mKeyguardManager.createConfirmDeviceCredentialIntent(null, null);
         if (intent != null) {
+          cordova.setActivityResultCallback(this);
           cordova.getActivity().startActivityForResult(intent, REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS);
         }
     }


### PR DESCRIPTION
When on "PIN fallback", it seems that the overriden "onActivityResult" is not called/triggered; hence, the successCallbak and errorCallback are not called as well.  ( ref - https://github.com/mjwheatley/cordova-plugin-android-fingerprint-auth/pull/65/commits )