### PR TITLE
Use resource-file tag for resources

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -28,32 +28,32 @@
         <source-file src="src/android/FingerprintAuth.java" target-dir="src/com/cordova/plugin/android/fingerprintauth" />
         <source-file src="src/android/FingerprintAuthenticationDialogFragment.java" target-dir="src/com/cordova/plugin/android/fingerprintauth" />
         <source-file src="src/android/FingerprintUiHelper.java" target-dir="src/com/cordova/plugin/android/fingerprintauth" />
-        <source-file src="res/android/drawable/ic_fingerprint_error.xml" target-dir="res/drawable" />
-        <source-file src="res/android/drawable/ic_fingerprint_success.xml" target-dir="res/drawable" />
-        <source-file src="res/android/drawable-hdpi/ic_fp_40px.png" target-dir="res/drawable-hdpi" />
-        <source-file src="res/android/drawable-mdpi/ic_fp_40px.png" target-dir="res/drawable-mdpi" />
-        <source-file src="res/android/drawable-nodpi/android_robot.png" target-dir="res/drawable-nodpi" />
-        <source-file src="res/android/drawable-xhdpi/ic_fp_40px.png" target-dir="res/drawable-xhdpi" />
-        <source-file src="res/android/drawable-xxhdpi/ic_fp_40px.png" target-dir="res/drawable-xxhdpi" />
-        <source-file src="res/android/drawable-xxxhdpi/ic_fp_40px.png" target-dir="res/drawable-xxxhdpi" />
-        <source-file src="res/android/layout/fingerprint_dialog_container.xml" target-dir="res/layout" />
-        <source-file src="res/android/layout/fingerprint_dialog_content.xml" target-dir="res/layout" />
-        <source-file src="res/android/values/fpauth-colors.xml" target-dir="res/values" />
-        <source-file src="res/android/values/fpauth-strings.xml" target-dir="res/values" />
-        <source-file src="res/android/values-it" target-dir="res" />
-        <source-file src="res/android/values-es" target-dir="res" />
-        <source-file src="res/android/values-ru" target-dir="res" />
-        <source-file src="res/android/values-fr" target-dir="res" />
-        <source-file src="res/android/values-zh" target-dir="res" />
-        <source-file src="res/android/values-zh-rCN" target-dir="res" />
-        <source-file src="res/android/values-zh-rHK" target-dir="res" />
-        <source-file src="res/android/values-zh-rMO" target-dir="res" />
-        <source-file src="res/android/values-zh-rSG" target-dir="res" />
-        <source-file src="res/android/values-zh-rTW" target-dir="res" />
-        <source-file src="res/android/values-no" target-dir="res" />
-        <source-file src="res/android/values-pt" target-dir="res" />
-        <source-file src="res/android/values-ja" target-dir="res" />
-        <source-file src="res/android/values-de" target-dir="res" />
+        <resource-file src="res/android/drawable/ic_fingerprint_error.xml" target="res/drawable/ic_fingerprint_error.xml" />
+        <resource-file src="res/android/drawable/ic_fingerprint_success.xml" target="res/drawable/ic_fingerprint_success.xml" />
+        <resource-file src="res/android/drawable-hdpi/ic_fp_40px.png" target="res/drawable-hdpi/ic_fp_40px.png" />
+        <resource-file src="res/android/drawable-mdpi/ic_fp_40px.png" target="res/drawable-mdpi/ic_fp_40px.png" />
+        <resource-file src="res/android/drawable-nodpi/android_robot.png" target="res/drawable-nodpi/android_robot.png" />
+        <resource-file src="res/android/drawable-xhdpi/ic_fp_40px.png" target="res/drawable-xhdpi/ic_fp_40px.png" />
+        <resource-file src="res/android/drawable-xxhdpi/ic_fp_40px.png" target="res/drawable-xxhdpi/ic_fp_40px.png" />
+        <resource-file src="res/android/drawable-xxxhdpi/ic_fp_40px.png" target="res/drawable-xxxhdpi/ic_fp_40px.png" />
+        <resource-file src="res/android/layout/fingerprint_dialog_container.xml" target="res/layout/fingerprint_dialog_container.xml" />
+        <resource-file src="res/android/layout/fingerprint_dialog_content.xml" target="res/layout/fingerprint_dialog_content.xml" />
+        <resource-file src="res/android/values/fpauth-colors.xml" target="res/values/fpauth-colors.xml" />
+        <resource-file src="res/android/values/fpauth-strings.xml" target="res/values/fpauth-strings.xml" />
+        <resource-file src="res/android/values-it" target="res/values-it" />
+        <resource-file src="res/android/values-es" target="res/values-es" />
+        <resource-file src="res/android/values-ru" target="res/values-ru" />
+        <resource-file src="res/android/values-fr" target="res/values-fr" />
+        <resource-file src="res/android/values-zh" target="res/values-zh" />
+        <resource-file src="res/android/values-zh-rCN" target="res/values-zh-rCN" />
+        <resource-file src="res/android/values-zh-rHK" target="res/values-zh-rHK" />
+        <resource-file src="res/android/values-zh-rMO" target="res/values-zh-rMO" />
+        <resource-file src="res/android/values-zh-rSG" target="res/values-zh-rSG" />
+        <resource-file src="res/android/values-zh-rTW" target="res/values-zh-rTW" />
+        <resource-file src="res/android/values-no" target="res/values-no" />
+        <resource-file src="res/android/values-pt" target="res/values-pt" />
+        <resource-file src="res/android/values-ja" target="res/values-ja" />
+        <resource-file src="res/android/values-de" target="res/values-de" />
 
     </platform>
 


### PR DESCRIPTION
Resources such as images, xml and folders should use resource-file tag instead of source-file (this one is for source code)

As side effect, it should fix https://github.com/mjwheatley/cordova-plugin-android-fingerprint-auth/issues/98

