### PR TITLE
FIX exception that KeyStore is not initialized when trying to delete entry

### DIFF
--- a/src/android/FingerprintAuth.java
+++ b/src/android/FingerprintAuth.java
@@ -389,11 +389,18 @@ public class FingerprintAuth extends CordovaPlugin {
                     boolean ivDeleted = false;
                     boolean secretKeyDeleted = false;
                     try {
+                        mKeyStore.load(null);
                         mKeyStore.deleteEntry(mClientId);
                         secretKeyDeleted = true;
                         ivDeleted = deleteIV();
                     } catch (KeyStoreException e) {
-                        Log.e(TAG, "Error while deleting SecretKey.");
+                        Log.e(TAG, "Error while deleting SecretKey.", e);
+                    } catch (CertificateException e) {
+                        Log.e(TAG, "Error while deleting SecretKey.", e);
+                    } catch (NoSuchAlgorithmException e) {
+                        Log.e(TAG, "Error while deleting SecretKey.", e);
+                    } catch (IOException e) {
+                        Log.e(TAG, "Error while deleting SecretKey.", e);
                     }
 
                     if (ivDeleted && secretKeyDeleted) {


### PR DESCRIPTION
If the `KeyStore` member has not been accessed before trying to `delete` an entry, an exception is triggered that the `KeyStore` has not been initialized yet.

This can be avoided by invoking `load(null)` before trying to `delete` an entry