### PR TITLE
Use the correct SPDX license id in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "cordova-android"
   ],
   "author": "Matthew Wheatley",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/mjwheatley/cordova-plugin-android-fingerprint-auth/issues"
   },


### PR DESCRIPTION
The license field in package.json expects an SPDX license identifier https://docs.npmjs.com/files/package.json#license

This isn't quiet right here according to https://spdx.org/licenses/
That breaks license check tools with rather strict matching logic.