### PR TITLE
Fix #136 android.content.res.Resources$NotFoundException

### DIFF
--- a/src/android/FingerprintAuthenticationDialogFragment.java
+++ b/src/android/FingerprintAuthenticationDialogFragment.java
@@ -60,6 +60,13 @@ public class FingerprintAuthenticationDialogFragment extends DialogFragment
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        // Gracefully close the Fingerprint dialog when plugin data is unrecoverable,
+        // possibly due to the OS killing the app while in the background.
+        if(FingerprintAuth.packageName == null){
+            Log.e(TAG, "Internal data loss, dismissing dialog");
+            dismissAllowingStateLoss();
+        }
+
         super.onCreate(savedInstanceState);
 
         // Do not create a new Fragment when the Activity is re-created such as orientation changes.


### PR DESCRIPTION
Fix the application crash when trying to get a resource by using an invalid application package name when the user resumes the app . The reason is that all plugin data, which was kept in memory, had been erased because OS had killed the application while this was on background.
This PR gracefully close the Fingerprint dialog when plugin data is unrecoverable.